### PR TITLE
Add Hwinfo toolbar item type

### DIFF
--- a/gen/schemas/toolbar_items.schema.json
+++ b/gen/schemas/toolbar_items.schema.json
@@ -319,6 +319,84 @@
         }
       }
     },
+    "HwinfoToolbarItem": {
+      "type": "object",
+      "properties": {
+        "badge": {
+          "description": "Badge will be displayed over the item, useful as notifications.\n\nShould follow the [mathjs expression syntax](https://mathjs.org/docs/expressions/syntax.html).\n\n## Hwinfo Item Scope\nthis module does no expand the scope of the item",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "id": {
+          "description": "Id to identify the item, should be unique.",
+          "type": "string",
+          "default": ""
+        },
+        "onClick": {
+          "description": "Deprecated use `onClickV2` instead.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "onClickV2": {
+          "description": "This code will be parsed and executed when the item is clicked.\n\nShould follow the [mathjs expression syntax](https://mathjs.org/docs/expressions/syntax.html).\n\n## Hwinfo Item Scope\nthis module does no expand the scope of the item",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "remoteData": {
+          "description": "Remote data to be added to the item scope.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/RemoteDataDeclaration"
+          },
+          "default": {}
+        },
+        "sensors": {
+          "description": "Sensors to query from the system",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "style": {
+          "description": "Styles to be added to the item. This follow the same interface of React's `style` prop.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/StyleValue"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "default": {}
+        },
+        "template": {
+          "description": "Content to display in the item.\n\nShould follow the [mathjs expression syntax](https://mathjs.org/docs/expressions/syntax.html).\n\n## Hwinfo Item Scope\nthis module does no expand the scope of the item",
+          "type": "string",
+          "default": ""
+        },
+        "tooltip": {
+          "description": "Content to display in tooltip of the item.\n\nShould follow the [mathjs expression syntax](https://mathjs.org/docs/expressions/syntax.html).\n\n## Hwinfo Item Scope\nthis module does no expand the scope of the item",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      }
+    },
     "KeyboardToolbarItem": {
       "type": "object",
       "properties": {
@@ -1034,6 +1112,19 @@
             }
           },
           "$ref": "#/$defs/SettingsToolbarItem",
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "hwinfo"
+            }
+          },
+          "$ref": "#/$defs/HwinfoToolbarItem",
           "required": [
             "type"
           ]

--- a/src/state/placeholder.rs
+++ b/src/state/placeholder.rs
@@ -319,6 +319,13 @@ common_item! {
     /// this module does no expand the scope of the item
     struct SettingsToolbarItem {}
 
+    /// ## Hwinfo Item Scope
+    /// this module does no expand the scope of the item
+    struct HwinfoToolbarItem {
+        /// Sensors to query from the system
+        sensors: Vec<String>,
+    }
+
     /// ## Workspace Item Scope
     /// this module does no expand the scope of the item
     struct WorkspaceToolbarItem {
@@ -342,6 +349,7 @@ pub enum ToolbarItem {
     Tray(TrayToolbarItem),
     Device(DeviceToolbarItem),
     Settings(SettingsToolbarItem),
+    Hwinfo(HwinfoToolbarItem),
     Workspaces(WorkspaceToolbarItem),
 }
 
@@ -361,6 +369,7 @@ impl ToolbarItem {
             ToolbarItem::Tray(item) => item.id.clone(),
             ToolbarItem::Device(item) => item.id.clone(),
             ToolbarItem::Settings(item) => item.id.clone(),
+            ToolbarItem::Hwinfo(item) => item.id.clone(),
             ToolbarItem::Workspaces(item) => item.id.clone(),
         }
     }
@@ -380,6 +389,7 @@ impl ToolbarItem {
             ToolbarItem::Tray(item) => item.id = id,
             ToolbarItem::Device(item) => item.id = id,
             ToolbarItem::Settings(item) => item.id = id,
+            ToolbarItem::Hwinfo(item) => item.id = id,
             ToolbarItem::Workspaces(item) => item.id = id,
         }
     }

--- a/src/state/placeholder.ts
+++ b/src/state/placeholder.ts
@@ -19,6 +19,7 @@ const ToolbarModuleType: Enum<ToolbarItem['type']> = {
   Notifications: 'notifications',
   Device: 'device',
   Settings: 'settings',
+  Hwinfo: 'hwinfo',
   Workspaces: 'workspaces',
 };
 


### PR DESCRIPTION
## Summary
- extend placeholder items with HwinfoToolbarItem
- add Hwinfo variant to ToolbarItem enum
- expose hwinfo module type in placeholder.ts
- regenerate toolbar_items schema

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_68732989cad88331bf3aa14693d538af