### PR TITLE
Add Hwinfo command and event

### DIFF
--- a/src/handlers/commands.rs
+++ b/src/handlers/commands.rs
@@ -183,6 +183,9 @@ slu_commands_declaration! {
     Shutdown = shutdown(),
     Lock = lock(),
 
+    // Hwinfo
+    GetHwinfoData = get_hwinfo_data(sensors: Vec<String>) -> HwInfo,
+
     // SeelenWeg
     WegGetItemsForWidget = weg_get_items_for_widget() -> WegItems,
     WegCloseApp = weg_close_app(hwnd: isize),

--- a/src/handlers/commands.ts
+++ b/src/handlers/commands.ts
@@ -70,6 +70,7 @@ export enum SeelenCommand {
   Restart = 'restart',
   Shutdown = 'shutdown',
   Lock = 'lock',
+  GetHwinfoData = 'get_hwinfo_data',
   WegGetItemsForWidget = 'weg_get_items_for_widget',
   WegCloseApp = 'weg_close_app',
   WegKillApp = 'weg_kill_app',

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -77,6 +77,8 @@ slu_events_declaration! {
 
     ColorsChanged(UIColors) as "colors-changed",
 
+    HwinfoDataChanged(HwInfo) as "hwinfo-data-changed",
+
     TrayInfo(Vec<TrayIcon>) as "tray-info",
 
     ToolbarOverlaped(bool) as "set-auto-hide",

--- a/src/handlers/events.ts
+++ b/src/handlers/events.ts
@@ -25,6 +25,7 @@ export enum SeelenEvent {
   PowerMode = 'power-mode',
   BatteriesStatus = 'batteries-status',
   ColorsChanged = 'colors-changed',
+  HwinfoDataChanged = 'hwinfo-data-changed',
   TrayInfo = 'tray-info',
   ToolbarOverlaped = 'set-auto-hide',
   WegOverlaped = 'set-auto-hide',


### PR DESCRIPTION
## Summary
- support querying HWINFO data via GetHwinfoData command
- allow widgets to subscribe to HwinfoDataChanged event
- regenerate TypeScript enums

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68734cd3a1b483318e25874f0f9b595c