### PR TITLE
Update README with hwinfo plugin example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,3 +35,17 @@ let myVariable: SeelenType = { ... };
 - [GitHub Repository](https://github.com/Seelen-Inc/slu-lib)
 - [NPM Package](https://npmjs.com/package/@seelen-ui/lib)
 - [JSR Documentation](https://jsr.io/@seelen-ui/lib)
+## Creating Plugins
+
+To extend Seelen UI with additional functionality, create a `.slu` file containing plugin information. The example below targets `@seelen/fancy-toolbar` and uses the `hwinfo` toolbar item.
+
+```yml
+id: "@username/hwinfo-demo"
+target: "@seelen/fancy-toolbar"
+plugin:
+  type: hwinfo
+  id: hwinfo-toolbar
+  sensors:
+    - CPU_TEMPERATURE
+    - GPU_TEMPERATURE
+```


### PR DESCRIPTION
## Summary
- document how to make a `.slu` plugin targeting `@seelen/fancy-toolbar`
- add example YAML snippet demonstrating `hwinfo` toolbar item and sensors

## Testing
- `deno check ./src/lib.ts` *(fails: JSR package manifest failed to load)*
- `deno fmt --check` *(fails: found not formatted files)*
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings` *(fails: clippy large enum variant warning)*
- `deno test` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68734eb43a148331a084f71953fb2812