### PR TITLE
Add hwinfo toolbar plugin example

### DIFF
--- a/plugins/hwinfo-monitor.slu
+++ b/plugins/hwinfo-monitor.slu
@@ -1,0 +1,8 @@
+id: "@codex/hwinfo-monitor"
+target: "@seelen/fancy-toolbar"
+plugin:
+  type: hwinfo
+  id: hwinfo-toolbar
+  sensors:
+    - CPU_TEMPERATURE
+    - GPU_TEMPERATURE


### PR DESCRIPTION
## Summary
- add example `.slu` file for the fancy-toolbar using the hwinfo plugin

## Testing
- `deno test --allow-all` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6873508a6aa48331a8ac58725ae1b341