### PR TITLE
Improve hwinfo plugin example

### DIFF
--- a/plugins/hwinfo-monitor.slu
+++ b/plugins/hwinfo-monitor.slu
@@ -1,0 +1,13 @@
+id: "@codex/hwinfo-monitor"
+metadata:
+  displayName:
+    en: "HWInfo Monitor"
+  description:
+    en: "Display CPU and GPU temperature in the toolbar"
+target: "@seelen/fancy-toolbar"
+plugin:
+  type: hwinfo
+  id: hwinfo-toolbar
+  sensors:
+    - CPU_TEMPERATURE
+    - GPU_TEMPERATURE

--- a/readme.md
+++ b/readme.md
@@ -49,3 +49,7 @@ plugin:
     - CPU_TEMPERATURE
     - GPU_TEMPERATURE
 ```
+
+Place this file inside Seelen UI's `plugins` directory (for example `%APPDATA%/Seelen/plugins` on Windows).
+Seelen UI will automatically detect the plugin at startup and show the CPU and GPU temperatures on the toolbar.
+You only need to clone this repository if you want to modify or build the library itself.


### PR DESCRIPTION
## Summary
- add metadata to `hwinfo-monitor.slu`
- clarify plugin installation steps in README

## Testing
- `deno test --allow-all` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6873508a6aa48331a8ac58725ae1b341